### PR TITLE
fix(android): load default GTM container resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,11 @@ npx cap sync
 ### Android Setup
 
 1. **Add GTM container file**
-   - Download your container from Google Tag Manager console (GTM-XXXXXX.json)
-   - Place the file in `android/app/src/main/assets/containers/`
-   - Create the `containers` directory if it doesn't exist
+   - Download the Android default container from Google Tag Manager
+   - Add it as a raw resource in `android/app/src/main/res/raw/`
+   - Rename the file if needed so it uses only lowercase letters, digits, and underscores
+   - The plugin resolves the resource name from your container ID, for example `GTM-ABCD12` becomes `res/raw/gtm_abcd12`
+   - If you use JSON instead of the downloaded binary, it must be a simple default-container JSON. Full GTM export JSON files are not supported by the Android SDK
 
 ## API
 
@@ -275,7 +277,7 @@ await GoogleTagManager.push({
 
 ### Android Issues
 
-1. **Container not found**: Verify the container file is in the correct location: `android/app/src/main/assets/containers/GTM-XXXXXX.json`
+1. **Container not found**: Verify the default container is available as `android/app/src/main/res/raw/gtm_xxxxxx` and that the resource name matches your container ID after lowercasing and replacing `-` with `_`
 
 2. **Initialization failures**: Check that the container ID matches your GTM container exactly.
 

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ await GoogleTagManager.push({
 
 ### Android Issues
 
-1. **Container not found**: Verify the default container is available as `android/app/src/main/res/raw/gtm_xxxxxx` and that the resource name matches your container ID after lowercasing and replacing `-` with `_`
+1. **Container not found**: Verify the default container is available under `android/app/src/main/res/raw/` with a filename like `gtm_xxxxxx.json` or `gtm_xxxxxx.bin`. The resource name (filename without the extension) must match your container ID after lowercasing and replacing `-` with `_`.
 
 2. **Initialization failures**: Check that the container ID matches your GTM container exactly.
 

--- a/android/src/main/java/app/capgo/gtm/GoogleTagManager.java
+++ b/android/src/main/java/app/capgo/gtm/GoogleTagManager.java
@@ -21,6 +21,7 @@ import java.util.concurrent.TimeUnit;
 public class GoogleTagManager {
 
     private static final String TAG = "GoogleTagManager";
+    private static final int MAX_FORMAT_SNIFF_BYTES = 8 * 1024;
     private Context context;
     private TagManager tagManager;
     private Container container;
@@ -147,17 +148,30 @@ public class GoogleTagManager {
             byte[] buffer = new byte[1024];
             int read;
 
-            while ((read = inputStream.read(buffer)) != -1) {
+            while (
+                outputStream.size() < MAX_FORMAT_SNIFF_BYTES
+                    && (
+                        read = inputStream.read(
+                            buffer,
+                            0,
+                            Math.min(buffer.length, remainingCapacity(outputStream))
+                        )
+                    ) != -1
+            ) {
                 outputStream.write(buffer, 0, read);
             }
 
-            String content = outputStream.toString(StandardCharsets.UTF_8);
+            String content = new String(outputStream.toByteArray(), StandardCharsets.UTF_8);
             return content.contains("\"exportFormatVersion\"")
                 && content.contains("\"containerVersion\"");
         } catch (Exception error) {
             Log.w(TAG, "Failed to inspect default GTM container resource " + resourceId, error);
             return false;
         }
+    }
+
+    private int remainingCapacity(ByteArrayOutputStream outputStream) {
+        return Math.max(1, MAX_FORMAT_SNIFF_BYTES - outputStream.size());
     }
 
     public void push(String event, Map<String, Object> parameters, Callback callback) {

--- a/android/src/main/java/app/capgo/gtm/GoogleTagManager.java
+++ b/android/src/main/java/app/capgo/gtm/GoogleTagManager.java
@@ -58,10 +58,7 @@ public class GoogleTagManager {
             int defaultContainerResourceId = resolveDefaultContainerResourceId(containerId);
 
             // Load container
-            PendingResult<ContainerHolder> pending = loadContainer(
-                containerId,
-                defaultContainerResourceId
-            );
+            PendingResult<ContainerHolder> pending = loadContainer(containerId, defaultContainerResourceId);
 
             pending.setResultCallback(
                 new ResultCallback<ContainerHolder>() {
@@ -87,32 +84,20 @@ public class GoogleTagManager {
     }
 
     private int resolveDefaultContainerResourceId(String containerId) {
-        String resourceName = containerId
-            .toLowerCase(Locale.US)
-            .replace('-', '_');
-        int resourceId = context.getResources().getIdentifier(
-            resourceName,
-            "raw",
-            context.getPackageName()
-        );
+        String resourceName = containerId.toLowerCase(Locale.US).replace('-', '_');
+        int resourceId = context.getResources().getIdentifier(resourceName, "raw", context.getPackageName());
 
         if (resourceId == 0) {
-            Log.w(
-                TAG,
-                "No default GTM container resource found for "
-                    + containerId
-                    + ". Expected res/raw/"
-                    + resourceName
-            );
+            Log.w(TAG, "No default GTM container resource found for " + containerId + ". Expected res/raw/" + resourceName);
             return -1;
         }
 
         if (isUnsupportedExportContainer(resourceId)) {
             Log.w(
                 TAG,
-                "Ignoring raw GTM resource "
-                    + resourceName
-                    + " because Android default containers must use the GTM default-container format."
+                "Ignoring raw GTM resource " +
+                    resourceName +
+                    " because Android default containers must use the GTM default-container format."
             );
             return -1;
         }
@@ -121,19 +106,12 @@ public class GoogleTagManager {
         return resourceId;
     }
 
-    private PendingResult<ContainerHolder> loadContainer(
-        String containerId,
-        int defaultContainerResourceId
-    ) {
+    private PendingResult<ContainerHolder> loadContainer(String containerId, int defaultContainerResourceId) {
         try {
             return tagManager.loadContainerPreferFresh(containerId, defaultContainerResourceId);
         } catch (RuntimeException error) {
             if (defaultContainerResourceId != -1) {
-                Log.w(
-                    TAG,
-                    "Default GTM container resource could not be loaded. Retrying network-only initialization.",
-                    error
-                );
+                Log.w(TAG, "Default GTM container resource could not be loaded. Retrying network-only initialization.", error);
                 return tagManager.loadContainerPreferFresh(containerId, -1);
             }
             throw error;
@@ -149,21 +127,14 @@ public class GoogleTagManager {
             int read;
 
             while (
-                outputStream.size() < MAX_FORMAT_SNIFF_BYTES
-                    && (
-                        read = inputStream.read(
-                            buffer,
-                            0,
-                            Math.min(buffer.length, remainingCapacity(outputStream))
-                        )
-                    ) != -1
+                outputStream.size() < MAX_FORMAT_SNIFF_BYTES &&
+                (read = inputStream.read(buffer, 0, Math.min(buffer.length, remainingCapacity(outputStream)))) != -1
             ) {
                 outputStream.write(buffer, 0, read);
             }
 
             String content = new String(outputStream.toByteArray(), StandardCharsets.UTF_8);
-            return content.contains("\"exportFormatVersion\"")
-                && content.contains("\"containerVersion\"");
+            return content.contains("\"exportFormatVersion\"") && content.contains("\"containerVersion\"");
         } catch (Exception error) {
             Log.w(TAG, "Failed to inspect default GTM container resource " + resourceId, error);
             return false;

--- a/android/src/main/java/app/capgo/gtm/GoogleTagManager.java
+++ b/android/src/main/java/app/capgo/gtm/GoogleTagManager.java
@@ -9,8 +9,12 @@ import com.google.android.gms.tagmanager.Container;
 import com.google.android.gms.tagmanager.ContainerHolder;
 import com.google.android.gms.tagmanager.DataLayer;
 import com.google.android.gms.tagmanager.TagManager;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -50,9 +54,13 @@ public class GoogleTagManager {
 
             // Set timeout
             long timeoutMs = timeout != null ? timeout.longValue() : 2000;
+            int defaultContainerResourceId = resolveDefaultContainerResourceId(containerId);
 
             // Load container
-            PendingResult<ContainerHolder> pending = tagManager.loadContainerPreferFresh(containerId, -1);
+            PendingResult<ContainerHolder> pending = loadContainer(
+                containerId,
+                defaultContainerResourceId
+            );
 
             pending.setResultCallback(
                 new ResultCallback<ContainerHolder>() {
@@ -74,6 +82,81 @@ public class GoogleTagManager {
         } catch (Exception e) {
             Log.e(TAG, "Failed to initialize GTM", e);
             callback.onFailure(e.getMessage());
+        }
+    }
+
+    private int resolveDefaultContainerResourceId(String containerId) {
+        String resourceName = containerId
+            .toLowerCase(Locale.US)
+            .replace('-', '_');
+        int resourceId = context.getResources().getIdentifier(
+            resourceName,
+            "raw",
+            context.getPackageName()
+        );
+
+        if (resourceId == 0) {
+            Log.w(
+                TAG,
+                "No default GTM container resource found for "
+                    + containerId
+                    + ". Expected res/raw/"
+                    + resourceName
+            );
+            return -1;
+        }
+
+        if (isUnsupportedExportContainer(resourceId)) {
+            Log.w(
+                TAG,
+                "Ignoring raw GTM resource "
+                    + resourceName
+                    + " because Android default containers must use the GTM default-container format."
+            );
+            return -1;
+        }
+
+        Log.d(TAG, "Using default GTM container resource " + resourceName + " (" + resourceId + ")");
+        return resourceId;
+    }
+
+    private PendingResult<ContainerHolder> loadContainer(
+        String containerId,
+        int defaultContainerResourceId
+    ) {
+        try {
+            return tagManager.loadContainerPreferFresh(containerId, defaultContainerResourceId);
+        } catch (RuntimeException error) {
+            if (defaultContainerResourceId != -1) {
+                Log.w(
+                    TAG,
+                    "Default GTM container resource could not be loaded. Retrying network-only initialization.",
+                    error
+                );
+                return tagManager.loadContainerPreferFresh(containerId, -1);
+            }
+            throw error;
+        }
+    }
+
+    private boolean isUnsupportedExportContainer(int resourceId) {
+        try (
+            InputStream inputStream = context.getResources().openRawResource(resourceId);
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream()
+        ) {
+            byte[] buffer = new byte[1024];
+            int read;
+
+            while ((read = inputStream.read(buffer)) != -1) {
+                outputStream.write(buffer, 0, read);
+            }
+
+            String content = outputStream.toString(StandardCharsets.UTF_8);
+            return content.contains("\"exportFormatVersion\"")
+                && content.contains("\"containerVersion\"");
+        } catch (Exception error) {
+            Log.w(TAG, "Failed to inspect default GTM container resource " + resourceId, error);
+            return false;
         }
     }
 


### PR DESCRIPTION
## Summary
- resolve the Android default container resource from the GTM container ID instead of always passing `-1`
- fall back to network-only loading when a local default resource cannot be parsed by the Android SDK
- correct the Android setup docs to use `res/raw` instead of `assets/containers`

## Root cause
The plugin currently calls `loadContainerPreferFresh(containerId, -1)`, which guarantees the Android SDK never receives a bundled default container resource ID. Google's Android GTM docs expect the default container to be added as a raw resource and passed as `R.raw.<name>`.

## Notes
- the plugin now resolves `GTM-ABCD12` as `res/raw/gtm_abcd12`
- full GTM export JSON files are explicitly ignored for Android default-container loading because the Android SDK expects the default-container format instead

## Verification
- `npm run build`
- `npm run verify:android`

## References
- https://developers.google.com/tag-platform/tag-manager/android/v4
- https://developers.google.com/android/reference/com/google/android/gms/tagmanager/TagManager

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated Android setup instructions to use Android raw resources for GTM container configuration instead of bundled JSON files.
  * Modified troubleshooting guide to reflect new container resource path and naming conventions.

* **Improvements**
  * Enhanced container loading to resolve resources from GTM container IDs and validate JSON format compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->