### PR TITLE
fix(ios): use GoogleTagManager 9

### DIFF
--- a/CapgoCapacitorGtm.podspec
+++ b/CapgoCapacitorGtm.podspec
@@ -13,6 +13,6 @@ Pod::Spec.new do |s|
   s.source_files = 'ios/Sources/**/*.{swift,h,m,c,cc,mm,cpp}'
   s.ios.deployment_target = '15.0'
   s.dependency 'Capacitor'
-  s.dependency 'GoogleTagManager', '~> 7.4.6'
+  s.dependency 'GoogleTagManager', '~> 9.0'
   s.swift_version = '5.1'
 end


### PR DESCRIPTION
Updates the CocoaPods dependency from `GoogleTagManager ~> 7.4.6` to `~> 9.0`.

Why:
- Capacitor 8 apps using current Firebase Analytics can resolve Firebase 12, which requires `GoogleUtilities/UserDefaults ~> 8.1`.
- `GoogleTagManager 7.4.6` resolves through older Google Analytics dependencies that require `GoogleUtilities/UserDefaults ~> 7.11`, causing CocoaPods resolution to fail.
- `GoogleTagManager 9.1.0` resolves with the current Firebase/GoogleUtilities stack.

Notes:
- Android duplicate-class handling is already represented by #28, so this PR intentionally only changes the iOS podspec.

Verification:
- `pod ipc spec CapgoCapacitorGtm.podspec`
- `bun run build`
- `bun run check:wiring`
- Verified in a Capacitor 8 app that `bunx cap sync ios` resolves with `GoogleTagManager 9.1.0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GoogleTagManager dependency to version 9.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->